### PR TITLE
remove line break for macOs installation

### DIFF
--- a/src/setup-pandoc.ts
+++ b/src/setup-pandoc.ts
@@ -116,7 +116,6 @@ async function installPandocMac(version: string) {
     "-pkg",
     path.join(tempDirectory, fileName),
     "-target",
-    "/",
   ]);
 }
 


### PR DESCRIPTION
It seems the line break is misinterpreted by the installer. 

like in my latest build (https://github.com/pydata/pydata-sphinx-theme/actions/runs/6328021184/job/17345901218):

where I got the following error: 
```
 /bin/sh: --version: command not found
  /usr/bin/sudo installer -allowUntrusted -dumplog -pkg /Users/runner/work/_temp/pandoc-3.1.8-x86_64-macOS.pkg -target /
  Error: Command failed:  --version
  /bin/sh: --version: command not found
```

This should solve it in wait that MacOS relies on .zip instead of the .pkg file